### PR TITLE
删除设置图标时修改图标大小的逻辑

### DIFF
--- a/FontAwesomeKit/FontAwesomeKit+UIKit.swift
+++ b/FontAwesomeKit/FontAwesomeKit+UIKit.swift
@@ -139,7 +139,7 @@ public extension FontAwesomeKit where Base: UIButton {
     /// - parameter type:  The fontAwesome type, and you don't need to 'setImage' or 'setBackgroundImage'
     /// - parameter state: The state that uses the specified title. The possible values are described in UIControlState.
     func setTitle(_ type: FontAwesomeType, for state: UIControl.State) {
-//        base.titleLabel?.font = UIFont.fa?.fontSize(28)
+        base.titleLabel?.font = UIFont.fa?.fontSize(base.titleLabel?.font.pointSize ?? 28)
         base.setTitle(type.fa.cCharString, for: state)
     }
 }

--- a/FontAwesomeKit/FontAwesomeKit+UIKit.swift
+++ b/FontAwesomeKit/FontAwesomeKit+UIKit.swift
@@ -139,7 +139,7 @@ public extension FontAwesomeKit where Base: UIButton {
     /// - parameter type:  The fontAwesome type, and you don't need to 'setImage' or 'setBackgroundImage'
     /// - parameter state: The state that uses the specified title. The possible values are described in UIControlState.
     func setTitle(_ type: FontAwesomeType, for state: UIControl.State) {
-        base.titleLabel?.font = UIFont.fa?.fontSize(28)
+//        base.titleLabel?.font = UIFont.fa?.fontSize(28)
         base.setTitle(type.fa.cCharString, for: state)
     }
 }


### PR DESCRIPTION
在使用过程中遇到UIButton设置字体大小被覆盖问题：
```
abtn.titleLabel?.font = UIFont.fa?.fontSize(12)
abtn.fa.setTitle(.eye , for: .normal)
abtn.fa.setTitle(.eyeSlash , for: .selected)
```